### PR TITLE
Make the code a bit cleaner

### DIFF
--- a/autoscraper/__init__.py
+++ b/autoscraper/__init__.py
@@ -1,1 +1,1 @@
-from .auto_scraper import AutoScraper
+from autoscraper.auto_scraper import AutoScraper

--- a/autoscraper/__init__.py
+++ b/autoscraper/__init__.py
@@ -1,1 +1,1 @@
-from autoscraper.auto_scraper import AutoScraper
+from .auto_scraper import AutoScraper

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -1,9 +1,9 @@
 import os
 import json
+from urllib.parse import urljoin, urlparse
 
 import requests
 from bs4 import BeautifulSoup
-from urllib.parse import urljoin, urlparse
 
 
 class AutoScraper(object):

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -1,6 +1,5 @@
 import os
 import json
-from functools import reduce
 from urllib.parse import urljoin, urlparse
 
 import requests

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -1,5 +1,6 @@
 import os
 import json
+from functools import reduce
 from urllib.parse import urljoin, urlparse
 
 import requests
@@ -78,12 +79,7 @@ class AutoScraper(object):
 
     @classmethod
     def unique(cls, item_list):
-        unique_list = []
-        for item in item_list:
-            if item not in unique_list:
-                unique_list.append(item)
-
-        return unique_list
+        return list(set(item_list))
 
     def build(self, url=None, wanted_list=None, html=None, request_args={}):
         self.url = url

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -7,6 +7,7 @@ from bs4 import BeautifulSoup
 
 from autoscraper.utils import unique
 
+
 class AutoScraper(object):
     request_headers = {
         'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 \
@@ -41,10 +42,10 @@ class AutoScraper(object):
 
         return BeautifulSoup(html, 'lxml')
 
-    @classmethod
-    def _get_valid_attrs(cls, item):
+    @staticmethod
+    def _get_valid_attrs(item):
         return {
-            k: v if v is not None else '' for k, v in item.attrs if k in {'class', 'style'}
+            k: v if v is not [] else '' for k, v in item.attrs.items() if k in {'class', 'style'}
         }
 
     def _child_has_text(self, child, text):
@@ -96,7 +97,7 @@ class AutoScraper(object):
 
         result_list = unique(result_list)
 
-        if all(item in wanted_list for all item in result_list):
+        if all(w in result_list for w in wanted_list):
             self.stack_list = unique(stack_list)
             return result_list
 

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -1,8 +1,9 @@
-import json
 import os
-from urllib.parse import urljoin, urlparse
+import json
+
 import requests
 from bs4 import BeautifulSoup
+from urllib.parse import urljoin, urlparse
 
 
 class AutoScraper(object):
@@ -23,20 +24,20 @@ class AutoScraper(object):
         with open(file_path, 'r') as f:
             self.stack_list = json.load(f)
 
-    @staticmethod
-    def _get_soup(url=None, html=None, request_args=None):
+    @classmethod
+    def _get_soup(cls, url=None, html=None, request_args=None):
         if html:
             return BeautifulSoup(html, 'lxml')
         request_args = request_args if request_args else {}
-        headers = dict(AutoScraper.request_headers)
+        headers = dict(cls.request_headers)
         if url:
             headers['Host'] = urlparse(url).netloc
         headers = request_args.get('headers', headers)
         html = requests.get(url, headers=headers, **request_args).text
         return BeautifulSoup(html, 'lxml')
 
-    @staticmethod
-    def _get_valid_attrs(item):
+    @classmethod
+    def _get_valid_attrs(cls, item):
         attrs = dict(item.attrs)
         for attr in item.attrs:
             if attr not in {'class', 'style'}:
@@ -76,8 +77,8 @@ class AutoScraper(object):
             filter(lambda x: self._child_has_text(x, text), children))
         return children
 
-    @staticmethod
-    def unique(item_list):
+    @classmethod
+    def unique(cls, item_list):
         unique_list = []
         for item in item_list:
             if item not in unique_list:
@@ -107,16 +108,16 @@ class AutoScraper(object):
 
         return None
 
-    @staticmethod
-    def _check_result(result, wanted_list):
+    @classmethod
+    def _check_result(cls, result, wanted_list):
         for w in wanted_list:
             if w not in result:
                 return False
         return True
 
-    @staticmethod
-    def _build_stack(child):
-        content = [(child.name, AutoScraper._get_valid_attrs(child))]
+    @classmethod
+    def _build_stack(cls, child):
+        content = [(child.name, cls._get_valid_attrs(child))]
 
         parent = child
         while True:
@@ -127,7 +128,7 @@ class AutoScraper(object):
             for i, c in enumerate(grand_parent.findAll(parent.name, recursive=False)):
                 if c == parent:
                     content.insert(
-                        0, (grand_parent.name, AutoScraper._get_valid_attrs(grand_parent), i))
+                        0, (grand_parent.name, cls._get_valid_attrs(grand_parent), i))
                     break
             if grand_parent.name == 'html':
                 break
@@ -140,7 +141,7 @@ class AutoScraper(object):
         return stack
 
     def _get_result_for_child(self, child, soup):
-        stack = AutoScraper._build_stack(child)
+        stack = self._build_stack(child)
         result = self._get_result_with_stack(stack, soup)
         return result, stack
 

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -40,16 +40,9 @@ class AutoScraper(object):
 
     @classmethod
     def _get_valid_attrs(cls, item):
-        attrs = dict(item.attrs)
-        for attr in item.attrs:
-            if attr not in {'class', 'style'}:
-                del attrs[attr]
-                continue
-
-            if attrs[attr] == []:
-                attrs[attr] = ''
-
-        return attrs
+        return {
+            k: v or '' for k, v in item.attrs if k in {'class', 'style'}
+        }
 
     def _child_has_text(self, child, text):
         child_text = child.getText().strip()

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -17,11 +17,11 @@ class AutoScraper(object):
 
     def save(self, file_path):
         with open(file_path, 'w') as f:
-            f.write(json.dumps(self.stack_list))
+            json.dump(self.stack_list, f)
 
     def load(self, file_path):
         with open(file_path, 'r') as f:
-            self.stack_list = json.loads(f.read())
+            self.stack_list = json.load(f)
 
     @staticmethod
     def _get_soup(url=None, html=None, request_args=None):

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -25,11 +25,10 @@ class AutoScraper(object):
             self.stack_list = json.load(f)
 
     @classmethod
-    def _get_soup(cls, url=None, html=None, request_args=None):
+    def _get_soup(cls, url=None, html=None, request_args={}):
         if html:
             return BeautifulSoup(html, 'lxml')
 
-        request_args = request_args if request_args else {}
         headers = dict(cls.request_headers)
         if url:
             headers['Host'] = urlparse(url).netloc
@@ -93,7 +92,7 @@ class AutoScraper(object):
 
         return unique_list
 
-    def build(self, url=None, wanted_list=None, html=None, request_args=None):
+    def build(self, url=None, wanted_list=None, html=None, request_args={}):
         self.url = url
         soup = self._get_soup(url=url, html=html, request_args=request_args)
 
@@ -213,7 +212,7 @@ class AutoScraper(object):
 
         return self.unique(result)
 
-    def get_result_exact(self, url=None, html=None, soup=None, request_args=None):
+    def get_result_exact(self, url=None, html=None, soup=None, request_args={}):
         if url:
             self.url = url
 
@@ -232,7 +231,7 @@ class AutoScraper(object):
 
         return self.unique(result)
 
-    def get_result(self, url=None, html=None, request_args=None):
+    def get_result(self, url=None, html=None, request_args={}):
         soup = self._get_soup(url=url, html=html, request_args=request_args)
         similar = self.get_result_similar(soup=soup)
         exact = self.get_result_exact(soup=soup)

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -28,7 +28,7 @@ class AutoScraper(object):
 
     @classmethod
     def _get_soup(cls, url=None, html=None, request_args=None):
-        request_args = request_args if request_args else {}
+        request_args = request_args or {}
 
         if html:
             return BeautifulSoup(html, 'lxml')

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -96,7 +96,7 @@ class AutoScraper(object):
 
         result_list = unique(result_list)
 
-        if forall(lambda x: x in wanted_list, result_list):
+        if all(item in wanted_list for all item in result_list):
             self.stack_list = unique(stack_list)
             return result_list
 

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 from urllib.parse import urljoin, urlparse
 
 import requests

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -45,7 +45,7 @@ class AutoScraper(object):
     @staticmethod
     def _get_valid_attrs(item):
         return {
-            k: v if v is not [] else '' for k, v in item.attrs.items() if k in {'class', 'style'}
+            k: v if v != [] else '' for k, v in item.attrs.items() if k in {'class', 'style'}
         }
 
     def _child_has_text(self, child, text):

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -53,7 +53,7 @@ class AutoScraper(object):
         return attrs
 
     def _child_has_text(self, child, text):
-        child_text = child.getText().strip().rstrip()
+        child_text = child.getText().strip()
         if text == child_text:
             child.wanted_attr = None
             return True
@@ -62,7 +62,7 @@ class AutoScraper(object):
             if not isinstance(value, str):
                 continue
 
-            value = value.strip().rstrip()
+            value = value.strip()
             if text == value:
                 child.wanted_attr = key
                 return True
@@ -77,7 +77,7 @@ class AutoScraper(object):
         return False
 
     def _get_children(self, soup, text):
-        text = text.strip().rstrip()
+        text = text.strip()
         children = reversed(soup.findChildren())
         children = list(
             filter(lambda x: self._child_has_text(x, text), children))
@@ -160,7 +160,7 @@ class AutoScraper(object):
 
     def _fetch_result_from_child(self, child, wanted_attr, is_full_url):
         if wanted_attr is None:
-            return child.getText().strip().rstrip()
+            return child.getText().strip()
 
         if wanted_attr not in child.attrs:
             return None

--- a/autoscraper/code_template.py
+++ b/autoscraper/code_template.py
@@ -16,7 +16,7 @@ class GeneratedAutoScraper(object):
         self.stack_list = "{STACK_LIST}"
 
     @classmethod
-    def _get_soup(url=None, html=None, request_args=None):
+    def _get_soup(cls, url=None, html=None, request_args=None):
         request_args = request_args or {}
 
         if html:

--- a/autoscraper/code_template.py
+++ b/autoscraper/code_template.py
@@ -15,7 +15,9 @@ class GeneratedAutoScraper(object):
         self.stack_list = "{STACK_LIST}"
 
     @classmethod
-    def _get_soup(url=None, html=None, request_args={}):
+    def _get_soup(url=None, html=None, request_args=None):
+        request_args = request_args or {}
+
         if html:
             return BeautifulSoup(html, 'lxml')
 
@@ -74,7 +76,7 @@ class GeneratedAutoScraper(object):
         result = self._fetch_result_from_child(p, stack['wanted_attr'], stack['is_full_url'])
         return result
 
-    def get_result_similar(self, url=None, html=None, soup=None, request_args={}):
+    def get_result_similar(self, url=None, html=None, soup=None, request_args=None):
         if url:
             self.url = url
 
@@ -87,7 +89,7 @@ class GeneratedAutoScraper(object):
 
         return self.unique(result)
 
-    def get_result_exact(self, url=None, html=None, soup=None, request_args={}):
+    def get_result_exact(self, url=None, html=None, soup=None, request_args=None):
         if url:
             self.url = url
 
@@ -104,7 +106,7 @@ class GeneratedAutoScraper(object):
 
         return self.unique(result)
 
-    def get_result(self, url=None, html=None, request_args={}):
+    def get_result(self, url=None, html=None, request_args=None):
         soup = self._get_soup(url=url, html=html, request_args=request_args)
         similar = self.get_result_similar(soup=soup)
         exact = self.get_result_exact(soup=soup)

--- a/autoscraper/code_template.py
+++ b/autoscraper/code_template.py
@@ -14,20 +14,20 @@ class GeneratedAutoScraper(object):
         self.url = ''
         self.stack_list = "{STACK_LIST}"
 
-    @staticmethod
+    @classmethod
     def _get_soup(url=None, html=None, request_args=None):
         if html:
             return BeautifulSoup(html, 'lxml')
         request_args = request_args if request_args else {}
-        headers = dict(GeneratedAutoScraper.request_headers)
+        headers = dict(cls.request_headers)
         if url:
             headers['Host'] = urlparse(url).netloc
         headers = request_args.get('headers', headers)
         html = requests.get(url, headers=headers, **request_args).text
         return BeautifulSoup(html, 'lxml')
 
-    @staticmethod
-    def unique(item_list):
+    @classmethod
+    def unique(cls, item_list):
         unique_list = []
         for item in item_list:
             if item not in unique_list:

--- a/autoscraper/code_template.py
+++ b/autoscraper/code_template.py
@@ -3,6 +3,7 @@ from urllib.parse import urljoin, urlparse
 import requests
 from bs4 import BeautifulSoup
 
+from autoscraper.utils import unique
 
 class GeneratedAutoScraper(object):
     request_headers = {
@@ -29,15 +30,6 @@ class GeneratedAutoScraper(object):
         html = requests.get(url, headers=headers, **request_args).text
 
         return BeautifulSoup(html, 'lxml')
-
-    @classmethod
-    def unique(cls, item_list):
-        unique_list = []
-        for item in item_list:
-            if item not in unique_list:
-                unique_list.append(item)
-
-        return unique_list
 
     def _fetch_result_from_child(self, child, wanted_attr, is_full_url):
         if wanted_attr is None:
@@ -87,7 +79,7 @@ class GeneratedAutoScraper(object):
         for stack in self.stack_list:
             result += self._get_result_with_stack(stack, soup)
 
-        return self.unique(result)
+        return unique(result)
 
     def get_result_exact(self, url=None, html=None, soup=None, request_args=None):
         if url:
@@ -104,7 +96,7 @@ class GeneratedAutoScraper(object):
             except IndexError:
                 continue
 
-        return self.unique(result)
+        return unique(result)
 
     def get_result(self, url=None, html=None, request_args=None):
         soup = self._get_soup(url=url, html=html, request_args=request_args)

--- a/autoscraper/code_template.py
+++ b/autoscraper/code_template.py
@@ -40,7 +40,7 @@ class GeneratedAutoScraper(object):
 
     def _fetch_result_from_child(self, child, wanted_attr, is_full_url):
         if wanted_attr is None:
-            return child.getText().strip().rstrip()
+            return child.getText().strip()
 
         if wanted_attr not in child.attrs:
             return None

--- a/autoscraper/code_template.py
+++ b/autoscraper/code_template.py
@@ -18,12 +18,15 @@ class GeneratedAutoScraper(object):
     def _get_soup(url=None, html=None, request_args=None):
         if html:
             return BeautifulSoup(html, 'lxml')
+
         request_args = request_args if request_args else {}
         headers = dict(cls.request_headers)
         if url:
             headers['Host'] = urlparse(url).netloc
+
         headers = request_args.get('headers', headers)
         html = requests.get(url, headers=headers, **request_args).text
+
         return BeautifulSoup(html, 'lxml')
 
     @classmethod
@@ -32,15 +35,19 @@ class GeneratedAutoScraper(object):
         for item in item_list:
             if item not in unique_list:
                 unique_list.append(item)
+
         return unique_list
 
     def _fetch_result_from_child(self, child, wanted_attr, is_full_url):
         if wanted_attr is None:
             return child.getText().strip().rstrip()
+
         if wanted_attr not in child.attrs:
             return None
+
         if is_full_url:
             return urljoin(self.url, child.attrs[wanted_attr])
+
         return child.attrs[wanted_attr]
 
     def _get_result_with_stack(self, stack, soup):
@@ -49,12 +56,14 @@ class GeneratedAutoScraper(object):
             children = []
             for parent in parents:
                 children += parent.findAll(item[0], item[1], recursive=False)
+
             parents = children
 
         wanted_attr = stack['wanted_attr']
         is_full_url = stack['is_full_url']
         result = [self._fetch_result_from_child(i, wanted_attr, is_full_url) for i in parents]
         result = list(filter(lambda x: x, result))
+
         return result
 
     def _get_result_with_stack_index_based(self, stack, soup):
@@ -62,34 +71,43 @@ class GeneratedAutoScraper(object):
         stack_content = stack['content']
         for index, item in enumerate(stack_content[:-1]):
             p = p.findAll(stack_content[index + 1][0], recursive=False)[item[2]]
+
         result = self._fetch_result_from_child(p, stack['wanted_attr'], stack['is_full_url'])
         return result
 
     def get_result_similar(self, url=None, html=None, soup=None, request_args=None):
         if url:
             self.url = url
+
         if not soup:
             soup = self._get_soup(url=url, html=html, request_args=request_args)
+
         result = []
         for stack in self.stack_list:
             result += self._get_result_with_stack(stack, soup)
+
         return self.unique(result)
 
     def get_result_exact(self, url=None, html=None, soup=None, request_args=None):
         if url:
             self.url = url
+
         if not soup:
             soup = self._get_soup(url=url, html=html, request_args=request_args)
+
         result = []
         for stack in self.stack_list:
             try:
                 result.append(self._get_result_with_stack_index_based(stack, soup))
+
             except IndexError:
                 continue
+
         return self.unique(result)
 
     def get_result(self, url=None, html=None, request_args=None):
         soup = self._get_soup(url=url, html=html, request_args=request_args)
         similar = self.get_result_similar(soup=soup)
         exact = self.get_result_exact(soup=soup)
+
         return similar, exact

--- a/autoscraper/code_template.py
+++ b/autoscraper/code_template.py
@@ -15,11 +15,10 @@ class GeneratedAutoScraper(object):
         self.stack_list = "{STACK_LIST}"
 
     @classmethod
-    def _get_soup(url=None, html=None, request_args=None):
+    def _get_soup(url=None, html=None, request_args={}):
         if html:
             return BeautifulSoup(html, 'lxml')
 
-        request_args = request_args if request_args else {}
         headers = dict(cls.request_headers)
         if url:
             headers['Host'] = urlparse(url).netloc
@@ -75,7 +74,7 @@ class GeneratedAutoScraper(object):
         result = self._fetch_result_from_child(p, stack['wanted_attr'], stack['is_full_url'])
         return result
 
-    def get_result_similar(self, url=None, html=None, soup=None, request_args=None):
+    def get_result_similar(self, url=None, html=None, soup=None, request_args={}):
         if url:
             self.url = url
 
@@ -88,7 +87,7 @@ class GeneratedAutoScraper(object):
 
         return self.unique(result)
 
-    def get_result_exact(self, url=None, html=None, soup=None, request_args=None):
+    def get_result_exact(self, url=None, html=None, soup=None, request_args={}):
         if url:
             self.url = url
 
@@ -105,7 +104,7 @@ class GeneratedAutoScraper(object):
 
         return self.unique(result)
 
-    def get_result(self, url=None, html=None, request_args=None):
+    def get_result(self, url=None, html=None, request_args={}):
         soup = self._get_soup(url=url, html=html, request_args=request_args)
         similar = self.get_result_similar(soup=soup)
         exact = self.get_result_exact(soup=soup)

--- a/autoscraper/utils.py
+++ b/autoscraper/utils.py
@@ -1,0 +1,14 @@
+def unique(lst):
+    unique_lst = []
+    for item in lst:
+        if item not in unique_lst:
+            unique_lst.append(item)
+
+    return unique_lst
+
+def forall(fn, lst):
+    for item in lst:
+        if not fn(lst):
+            return False
+
+    return True

--- a/autoscraper/utils.py
+++ b/autoscraper/utils.py
@@ -6,9 +6,3 @@ def unique(lst):
 
     return unique_lst
 
-def forall(fn, lst):
-    for item in lst:
-        if not fn(lst):
-            return False
-
-    return True


### PR DESCRIPTION
Refactor to use some better and cleaner practices.
Changes are descriptive enough through commit messages, but here is short summary:

- it's much better to let the json.dump and json.load handle the read/write, so I replaced json.dumps and json.loads by them.
- for a library, absolute import is overkill, so I replaced them (there was only one in __init__.py) by relative import of equivalent.
- staticmethod wrapper is bound to parent class, so on method overrides, the behavior won't be altered, which is driven by forced bad practice of making hard dependency to the class name. thus I replaced them by classmethod wrapper.
- made the code more readable by (hopefully) appropriated blank lines in-between indentation shrinks (e.g. end of if-caluse and for-loop) and related set of chained statements.
- changed the order of imports to be (sorta) alphabetical and separated import of builtin, third party and internal modules/packages in same order respectively.
- str.strip method strips from both sides, no rstrip is required afterwards, so I removed them overheads.
- replaced request_args parameters' default value being None by {} to remove overhead if-else checks.
- replaced the definition of AutoScraper._get_valid_attrs and AutoSrcaper.unique methods by one linear readable alternatives.