### PR TITLE
Replace filter with list comprehensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,5 +123,8 @@ And to load:
 scraper.load('yahoo-finance')
 ```
 
-Check out [here](https://gist.github.com/alirezamika/72083221891eecd991bbc0a2a2467673) for more advanced usages.
+**See [here](https://gist.github.com/alirezamika/72083221891eecd991bbc0a2a2467673) for more advanced usages.**
+
+<a href="https://www.buymeacoffee.com/alirezam" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
+
 #### Happy Coding  ♥️

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -85,7 +85,7 @@ class AutoScraper(object):
     def _get_children(self, soup, text):
         text = text.strip()
         children = reversed(soup.findChildren())
-        children = list(filter(lambda x: self._child_has_text(x, text), children))
+        children = [x for x in children if self._child_has_text(x, text)]
         return children
 
     def build(self, url=None, wanted_list=None, html=None, request_args=None):
@@ -169,7 +169,7 @@ class AutoScraper(object):
         wanted_attr = stack['wanted_attr']
         is_full_url = stack['is_full_url']
         result = [self._fetch_result_from_child(i, wanted_attr, is_full_url) for i in parents]
-        result = list(filter(lambda x: x, result))
+        result = [x for x in result if x]
         return result
 
     def _get_result_with_stack_index_based(self, stack, soup):
@@ -184,7 +184,7 @@ class AutoScraper(object):
             p = p[idx]
 
         result = [self._fetch_result_from_child(p, stack['wanted_attr'], stack['is_full_url'])]
-        result = list(filter(lambda x: x, result))
+        result = [x for x in result if x]
         return result
 
     def _get_result_by_func(self, func, url, html, soup, request_args, grouped):
@@ -223,10 +223,10 @@ class AutoScraper(object):
         return similar, exact
 
     def remove_rules(self, rules):
-        self.stack_list = list(filter(lambda x: x['stack_id'] not in rules, self.stack_list))
+        self.stack_list = [x for x in self.stack_list if x['stack_id'] not in rules]
 
     def keep_rules(self, rules):
-        self.stack_list = list(filter(lambda x: x['stack_id'] in rules, self.stack_list))
+        self.stack_list = [x for x in self.stack_list if x['stack_id'] in rules]
 
     def generate_python_code(self):
         # deprecated

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -311,6 +311,7 @@ class AutoScraper(object):
         --------
         None
         """
+
         self.stack_list = [x for x in self.stack_list if x['stack_id'] not in rules]
 
     def keep_rules(self, rules):
@@ -322,6 +323,7 @@ class AutoScraper(object):
         rules : list
             A list of rules to keep in stack_list.
         """
+
         self.stack_list = [x for x in self.stack_list if x['stack_id'] in rules]
 
     def generate_python_code(self):

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -299,11 +299,6 @@ class AutoScraper(object):
         return similar, exact
 
     def remove_rules(self, rules):
-<<<<<<< HEAD
-        self.stack_list = [x for x in self.stack_list if x['stack_id'] not in rules]
-
-    def keep_rules(self, rules):
-=======
         """
         Removes a list of learned rules from stack_list.
 
@@ -316,7 +311,6 @@ class AutoScraper(object):
         --------
         None
         """
-
         self.stack_list = [x for x in self.stack_list if x['stack_id'] not in rules]
 
     def keep_rules(self, rules):
@@ -328,8 +322,6 @@ class AutoScraper(object):
         rules : list
             A list of rules to keep in stack_list.
         """
-
->>>>>>> 69dbdc1e1cd0943578ea0fd0b4bb2a836a262fdb
         self.stack_list = [x for x in self.stack_list if x['stack_id'] in rules]
 
     def generate_python_code(self):


### PR DESCRIPTION
Hi, I was looking through the code and thought it would be a good idea to replace `list(filter(something)` with list comprehensions since they allow to do the same thing but in a more readable way