### PR TITLE
Added metadata field

### DIFF
--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -44,9 +44,16 @@ class AutoScraper(object):
 
     def __init__(self, stack_list=None):
         self.stack_list = stack_list or []
-        self._metadata = {}
+        self._metadata = {
+            "model_name" : "",
+            "author" : "",
+            "author_email" : "",
+            "description" : "",
+            "keywords" : [],
+            "target_urls" : []
+        }
 
-    def save(self, file_path, metadata = {}):
+    def save(self, file_path):
         """
         Serializes the stack_list as JSON and saves it to the disk.
 
@@ -59,8 +66,7 @@ class AutoScraper(object):
         -------
         None
         """
-        metadata_to_save = metadata if (metadata and metadata != {}) else self._metadata
-        data = dict(stack_list=self.stack_list, metadata = metadata_to_save)
+        data = dict(stack_list=self.stack_list, metadata = self._metadata)
         with open(file_path, 'w') as f:
             json.dump(data, f)
 
@@ -194,6 +200,16 @@ class AutoScraper(object):
         if all(w in result_list for w in wanted_list):
             self.stack_list = unique_stack_list(self.stack_list)
             return result_list
+        
+
+        #add url to metadata 
+        if not update and url :
+            self._metadata['target_urls'] = [url]
+        elif update and url :
+            if not 'target_urls' in self._metadata :
+                self._metadata['target_urls'] = [url]
+            else :
+                self._metadata['target_urls'].append(url)
 
         return None
 
@@ -422,7 +438,7 @@ class AutoScraper(object):
         print('This function is deprecated. Please use save() and load() instead.')
     
 
-    def set_metadata(self, metadata = {}) :
+    def set_metadata(self, model_name = "", author = "", author_email = "", description = "", keywords = []) :
         """
         Set an optional metadata which will be saved along with the rules
         Parameters:
@@ -433,7 +449,11 @@ class AutoScraper(object):
         ---------
         None
         """
-        self._metadata = metadata
+        self._metadata['model_name'] = model_name
+        self._metadata['author'] = author
+        self._metadata['author_email'] = author_email
+        self._metadata['description'] = description
+        self._metadata['keywords'] = keywords
     
     def get_metadata(self) :
         """

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -19,6 +19,8 @@ class AutoScraper(object):
     ----------
     stack_list: list
         List of rules learned by AutoScraper
+    metadata : dict
+        Optional information assiociated with the learned rules.
 
     Methods
     -------
@@ -31,6 +33,8 @@ class AutoScraper(object):
     load() - De-serializes the JSON representation of the stack_list and loads it back.
     remove_rules() - Removes one or more learned rule[s] from the stack_list.
     keep_rules() - Keeps only the specified learned rules in the stack_list and removes the others.
+    set_metadata() - Set an optional metadata which will be saved along with the rules.
+    get_metadata() - Get metadata assiociated with the loaded rules.
     """
 
     request_headers = {
@@ -40,8 +44,9 @@ class AutoScraper(object):
 
     def __init__(self, stack_list=None):
         self.stack_list = stack_list or []
+        self._metadata = {}
 
-    def save(self, file_path):
+    def save(self, file_path, metadata = {}):
         """
         Serializes the stack_list as JSON and saves it to the disk.
 
@@ -54,8 +59,8 @@ class AutoScraper(object):
         -------
         None
         """
-
-        data = dict(stack_list=self.stack_list)
+        metadata_to_save = metadata if (metadata and metadata != {}) else self._metadata
+        data = dict(stack_list=self.stack_list, metadata = metadata_to_save)
         with open(file_path, 'w') as f:
             json.dump(data, f)
 
@@ -82,6 +87,7 @@ class AutoScraper(object):
             return
 
         self.stack_list = data['stack_list']
+        self._metadata = data['metadata']
 
     @classmethod
     def _get_soup(cls, url=None, html=None, request_args=None):
@@ -414,3 +420,30 @@ class AutoScraper(object):
     def generate_python_code(self):
         # deprecated
         print('This function is deprecated. Please use save() and load() instead.')
+    
+
+    def set_metadata(self, metadata = {}) :
+        """
+        Set an optional metadata which will be saved along with the rules
+        Parameters:
+        ----------
+        metadata: dict, optional
+                    A dict that contains additional information to be assiociated with the learnt rules.
+        Returns:
+        ---------
+        None
+        """
+        self._metadata = metadata
+    
+    def get_metadata(self) :
+        """
+        Get metadata assiociated with the loaded rules.
+        Parameters:
+        -----------
+        None
+
+        Returns
+        --------
+        A dict representing metadata assiociated with the learnt rules.
+        """
+        return self._metadata

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -443,8 +443,16 @@ class AutoScraper(object):
         Set an optional metadata which will be saved along with the rules
         Parameters:
         ----------
-        metadata: dict, optional
-                    A dict that contains additional information to be assiociated with the learnt rules.
+        model_name: str, optional
+                    Name of the model
+        author : str, optional
+                    Name of the author
+        author_email : str, optional
+                    Author email address
+        description : str, optional
+                    Description of the model
+        keywords : list, optional
+                    A list of keywords assiociated with the model
         Returns:
         ---------
         None
@@ -465,5 +473,12 @@ class AutoScraper(object):
         Returns
         --------
         A dict representing metadata assiociated with the learnt rules.
+        Fields:
+            author : Name of the author
+            author_email : Email address of the author
+            model_name : Name of the model 
+            description : A short description of the model
+            keywords : A list of keywords
+            target_urls : A list of target urls used for learning the rules.
         """
         return self._metadata


### PR DESCRIPTION
This new PR allows users to add metadata dictionary and save/load it. Since metadata is a generic dict, users are free to add any kind of metadata. Some examples include - Author, license, description etc. This provides an identity to the learnt rules. (would be useful for those who publish their work)
1.  Added `set_metadata()` and `get_metadata()` to bring in these features.
2. Changes  are made to `load()` and `save()`
3. Updated docs reflecting these features.

Metadata field would be useful, we can save any sort of information along with the rules. In future if you try to add any other fields to the saved representation you can include them in metadata field, without making any major change to the codebase. 