### PR TITLE
replace fuzzywuzzy with difflib

### DIFF
--- a/autoscraper/utils.py
+++ b/autoscraper/utils.py
@@ -2,11 +2,8 @@ from collections import OrderedDict
 
 import random
 import string
-import warnings
 
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    from fuzzywuzzy import fuzz
+from difflib import SequenceMatcher
 
 
 def unique_stack_list(stack_list):
@@ -51,4 +48,4 @@ class FuzzyText(object):
         self.match = None
 
     def search(self, text):
-        return fuzz.ratio(self.text, text)/100. >= self.ratio_limit
+        return SequenceMatcher(None, self.text, text).ratio() >= self.ratio_limit

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,6 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
 
     python_requires='>=3.6',
-    install_requires=['requests', 'bs4', 'lxml', 'fuzzywuzzy'],
+    install_requires=['requests', 'bs4', 'lxml'],
 
 )


### PR DESCRIPTION
When using the slower version of FuzzyWuzzy it is using difflib internally, so there is not really a need to add a GPL licensed dependency for this. (When better performance is required [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) is a faster alternative to Fuzzywuzzy, thats MIT Licensed aswell)