### PR TITLE
Add XPath export feature

### DIFF
--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -737,9 +737,7 @@ class AutoScraper(object):
                 if not val:
                     continue
                 if isinstance(val, (list, tuple)):
-                    val = " ".join(str(v).strip() for v in val).strip()
-                if isinstance(val, str):
-                    val = val.strip()
+                    val = " ".join(str(v) for v in val)
 
                 if '"' in val and "'" in val:
                     parts = val.split('"')

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -720,6 +720,45 @@ class AutoScraper(object):
         for rule_id, alias in rule_aliases.items():
             id_to_stack[rule_id]["alias"] = alias
 
+    @staticmethod
+    def _stack_to_xpath(stack):
+        """Return an XPath expression for the given rule stack."""
+
+        path_parts = []
+        content = stack.get("content", [])
+        for idx, item in enumerate(content):
+            tag = item[0]
+            if tag == "[document]":
+                continue
+
+            attrs = item[1]
+            attr_conditions = []
+            for attr, val in attrs.items():
+                if not val:
+                    continue
+                if isinstance(val, (list, tuple)):
+                    val = " ".join(val)
+                attr_conditions.append(f"@{attr}=\"{val}\"")
+            cond = ""
+            if attr_conditions:
+                cond = "[" + " and ".join(attr_conditions) + "]"
+
+            index_part = ""
+            if idx > 0 and len(content[idx - 1]) > 2:
+                index_part = f"[{content[idx - 1][2] + 1}]"
+
+            path_parts.append(f"/{tag}{cond}{index_part}")
+
+        return "".join(path_parts)
+
+    def get_rule_xpaths(self):
+        """Return a dictionary mapping rule_id to XPath expression."""
+
+        return {
+            stack["stack_id"]: self._stack_to_xpath(stack)
+            for stack in self.stack_list
+        }
+
     def generate_python_code(self):
         # deprecated
         print("This function is deprecated. Please use save() and load() instead.")

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -737,9 +737,9 @@ class AutoScraper(object):
                 if not val:
                     continue
                 if isinstance(val, (list, tuple)):
-                    val = " ".join(str(v) for v in val)
+                    val = " ".join(str(v).strip() for v in val).strip()
                 if isinstance(val, str):
-                    val = val
+                    val = val.strip()
 
                 if '"' in val and "'" in val:
                     parts = val.split('"')

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -737,10 +737,19 @@ class AutoScraper(object):
                 if not val:
                     continue
                 if isinstance(val, (list, tuple)):
-                    val = " ".join(str(v).strip() for v in val)
+                    val = " ".join(str(v) for v in val)
                 if isinstance(val, str):
-                    val = val.strip()
-                attr_conditions.append(f"@{attr}=\"{val}\"")
+                    val = val
+
+                if '"' in val and "'" in val:
+                    parts = val.split('"')
+                    quoted = 'concat(' + ', "\"", '.join(f'"{p}"' for p in parts[:-1]) + (', ' if len(parts) > 1 else '') + f'"{parts[-1]}")'
+                elif '"' in val:
+                    quoted = f"'{val}'"
+                else:
+                    quoted = f'"{val}"'
+
+                attr_conditions.append(f"@{attr}={quoted}")
             cond = ""
             if attr_conditions:
                 cond = "[" + " and ".join(attr_conditions) + "]"

--- a/autoscraper/auto_scraper.py
+++ b/autoscraper/auto_scraper.py
@@ -737,7 +737,9 @@ class AutoScraper(object):
                 if not val:
                     continue
                 if isinstance(val, (list, tuple)):
-                    val = " ".join(val)
+                    val = " ".join(str(v).strip() for v in val)
+                if isinstance(val, str):
+                    val = val.strip()
                 attr_conditions.append(f"@{attr}=\"{val}\"")
             cond = ""
             if attr_conditions:

--- a/tests/integration/test_complex_features.py
+++ b/tests/integration/test_complex_features.py
@@ -75,3 +75,44 @@ def test_attr_fuzz_ratio():
     scraper.build(html=html_base, wanted_list=["Buy"])
     res = scraper.get_result_exact(html=html_variant, attr_fuzz_ratio=0.8)
     assert res == ["Buy"]
+
+
+COMPLEX_HTML_XPATH = """
+<div id="content">
+  <section class="products">
+    <div class="item featured" data-sku="123">
+      <div class="header">
+        <h2 class="name">Banana</h2>
+        <span class="price">$1</span>
+      </div>
+      <div class="meta">
+        <span class="rating">4.5</span>
+        <a href="/banana" class="link">View</a>
+      </div>
+    </div>
+    <div class="item" data-sku="456">
+      <div class="header">
+        <h2 class="name">Apple</h2>
+        <span class="price">$2</span>
+      </div>
+      <div class="meta">
+        <span class="rating">4.2</span>
+        <a href="/apple" class="link">View</a>
+      </div>
+    </div>
+  </section>
+</div>
+"""
+
+
+def test_get_rule_xpaths_complex_html():
+    scraper = AutoScraper()
+    scraper.build(html=COMPLEX_HTML_XPATH, wanted_list=["Apple", "$2", "4.2"])
+    rule_xpaths = scraper.get_rule_xpaths()
+    expected = {
+        "/div[1]/section[@class=\"products\"][1]/div[@class=\"item\"][1]/div[@class=\"header\"][1]/h2[@class=\"name\"][1]",
+        "/div[1]/section[@class=\"products\"][1]/div[@class=\"item\"][1]/div[@class=\"header\"][1]/span[@class=\"price\"][1]",
+        "/div[1]/section[@class=\"products\"][1]/div[@class=\"item\"][1]/div[@class=\"meta\"][1]/span[@class=\"rating\"][1]",
+    }
+    assert set(rule_xpaths.values()) == expected
+

--- a/tests/unit/test_additional_features.py
+++ b/tests/unit/test_additional_features.py
@@ -39,3 +39,11 @@ def test_similar_keep_order():
     scraper.build(html=HTML, wanted_list=["Banana"])
     result = scraper.get_result_similar(html=HTML, contain_sibling_leaves=True, keep_order=True)
     assert result == ["Banana", "Apple", "Orange"]
+
+
+def test_get_rule_xpaths():
+    scraper = AutoScraper()
+    scraper.build(html=HTML, wanted_list=["Banana"])
+    rule_id = scraper.stack_list[0]["stack_id"]
+    xpaths = scraper.get_rule_xpaths()
+    assert xpaths[rule_id] == "/ul[1]/li[1]"

--- a/tests/unit/test_additional_features.py
+++ b/tests/unit/test_additional_features.py
@@ -55,4 +55,4 @@ def test_get_rule_xpaths_preserves_spaces():
     scraper.build(html=html, wanted_list=["t"])
     rule_id = scraper.stack_list[0]["stack_id"]
     xpaths = scraper.get_rule_xpaths()
-    assert xpaths[rule_id] == '/div[@style="color: red;"][1]'
+    assert xpaths[rule_id] == '/div[@style=" color: red; "][1]'

--- a/tests/unit/test_additional_features.py
+++ b/tests/unit/test_additional_features.py
@@ -55,4 +55,4 @@ def test_get_rule_xpaths_preserves_spaces():
     scraper.build(html=html, wanted_list=["t"])
     rule_id = scraper.stack_list[0]["stack_id"]
     xpaths = scraper.get_rule_xpaths()
-    assert xpaths[rule_id] == '/div[@style=" color: red; "][1]'
+    assert xpaths[rule_id] == '/div[@style="color: red;"][1]'

--- a/tests/unit/test_additional_features.py
+++ b/tests/unit/test_additional_features.py
@@ -47,3 +47,12 @@ def test_get_rule_xpaths():
     rule_id = scraper.stack_list[0]["stack_id"]
     xpaths = scraper.get_rule_xpaths()
     assert xpaths[rule_id] == "/ul[1]/li[1]"
+
+
+def test_get_rule_xpaths_preserves_spaces():
+    html = '<div style=" color: red; ">t</div>'
+    scraper = AutoScraper()
+    scraper.build(html=html, wanted_list=["t"])
+    rule_id = scraper.stack_list[0]["stack_id"]
+    xpaths = scraper.get_rule_xpaths()
+    assert xpaths[rule_id] == '/div[@style=" color: red; "][1]'


### PR DESCRIPTION
## Summary
- implement `_stack_to_xpath` to convert rule stack to an XPath expression
- add `get_rule_xpaths` to retrieve XPaths for learned rules
- test the new API in `test_get_rule_xpaths`
- add complex HTML integration test for rule XPath extraction
- refine complex HTML XPath assertions to check exact values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684594a02a408320a9d83114857972d4